### PR TITLE
Ignore negative values

### DIFF
--- a/custom_components/veolia/__init__.py
+++ b/custom_components/veolia/__init__.py
@@ -65,6 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         if (
             previous_data
             and previous_data[LAST_REPORT_TIMESTAMP] == last_report_timestamp
+            and previous_data[DAILY][-1] > 0
         ):
             return previous_data
 

--- a/custom_components/veolia/sensor.py
+++ b/custom_components/veolia/sensor.py
@@ -45,7 +45,12 @@ class VeoliaDailyUsageSensor(VeoliaEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self.coordinator.data[DAILY][-1]
+        state = self.coordinator.data[DAILY][-1]
+
+        if state > 0:
+            return state
+
+        return None
 
 
 class VeoliaMonthlyUsageSensor(VeoliaEntity):
@@ -59,4 +64,8 @@ class VeoliaMonthlyUsageSensor(VeoliaEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return sum(self.coordinator.data[DAILY])
+        state = sum(self.coordinator.data[DAILY])
+        if state > 0:
+            return state
+
+        return None


### PR DESCRIPTION
Fix #22

Sometimes Veolia returns invalid values, like a huge number. They fix this value sending just after a huge negative number. At the end the error is resolved, and does not appear anymore.

```csv
date;consommation(litre)
01/03/2018;275
02/03/2018;154
03/03/2018;379
03/03/2018;-1754359
04/03/2018;1754558
```