### PR TITLE
Update entity.py

### DIFF
--- a/custom_components/veolia/entity.py
+++ b/custom_components/veolia/entity.py
@@ -26,7 +26,7 @@ class VeoliaEntity(CoordinatorEntity):
         }
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return {
             "last_report": self.coordinator.data[LAST_REPORT_TIMESTAMP],


### PR DESCRIPTION
WARNING (MainThread) [homeassistant.helpers.entity] Entity sensor.veolia_monthly_consumption (<class 'custom_components.veolia.sensor.VeoliaMonthlyUsageSensor'>) implements device_state_attributes. Please report it to the custom component author.

As from version HA 2021.12 device_state_attributes is deprecated and should be replaced by extra_state_attributes.